### PR TITLE
Change 'open' to use platform dependent call

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -52,7 +52,7 @@ convert_pptx <- function(path, author, title = NULL, sub = NULL,
     unlink("assets", recursive = TRUE)
   }
 
-  system(paste("open", rmd))
+  system(paste(Sys.getenv("R_BROWSER"), rmd))
 }
 
 


### PR DESCRIPTION
`Sys.getenv("R_BROWSER")` seems to give the correct open call. I think `open` is the Mac default, but it's `xdg-open` on Linux.

Reference: https://stackoverflow.com/a/43713588/4303355

Thanks for the package!