### PR TITLE
Internalize utils.R functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,11 @@ Description: This package is designed to extract information from Microsoft
   links. Tables are also generally maintained, although they may require some
   manual editing if complex spanner heads and merged cells were used in the 
   original table. Nested bulleted lists should also be maintained.
-Authors@R: person("Daniel", "Anderson", email = "daniela@uoregon.edu", role = c("aut", "cre"))
+Authors@R: c(
+    person("Daniel", "Anderson", email = "daniela@uoregon.edu", role = c("aut", "cre")),
+    person("Patrick", "Kennedy", email = "pkqstr@protonmail.com", role = c("ctb"),
+           comment = c(ORCID = "0000-0002-5525-3983"))
+  )
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,6 +18,7 @@ check_lang <- function(xml_folder) {
 #' @param force If an 'assets' folder already exists in the current directory,
 #'   (e.g., from a previous conversion) should it be overwritten? Defaults to
 #'   \code{FALSE}.
+#' @keywords internal
 
 extract_xml <- function(path, force = FALSE) {
   ppt <- basename(path)
@@ -61,6 +62,7 @@ extract_xml <- function(path, force = FALSE) {
 #'
 #' @param xml_folder The folder containing all of the xml code from the pptx,
 #' created from \code{\link{extract_xml}}.
+#' @keywords internal
 
 import_slide_xml <- function(xml_folder) {
   slds <- file.path(xml_folder, "ppt", "slides") %>%
@@ -84,6 +86,7 @@ import_slide_xml <- function(xml_folder) {
 #'
 #' @param xml_folder The folder containing all of the xml code from the pptx,
 #' created from \code{\link{extract_xml}}.
+#' @keywords internal
 
 import_rel_xml <- function(xml_folder) {
   rels <- file.path(xml_folder, "ppt", "slides", "_rels") %>%
@@ -112,6 +115,8 @@ extract_class <- function(sld) {
 #'
 #' @param sld xml code for the slide to extract the title from
 #'
+#' @keywords internal
+
 extract_title <- function(sld) {
   classes <- extract_class(sld)
 
@@ -155,6 +160,8 @@ max_amount <- function(x) {
 #'
 #' @param sld xml code for the slide to extract the title from
 #'
+#' @keywords internal
+
 extract_body <- function(sld) {
 
   sps <- xml_find_all(sld, "//p:sp")
@@ -271,6 +278,7 @@ extract_footnote <- function(sld) {
 #' @param attr Attribute to extract. Currently takes two valide arguments:
 #'   \code{"image"} or \code{"link"} to extract images or links, respectively.
 #' @param sld xml code for the slide to extract the title from
+#' @keywords internal
 
 # xml_folder will need to be another argument if the commented code below is
 # incorporated
@@ -356,6 +364,7 @@ extract_image <- function(sld, rel) {
 #' @return a \code{data.frame} with the data from the table. Generally fed to
 #'   \code{\link{tribble_code}}.
 #'
+#' @keywords internal
 
 extract_table <- function(sld) {
   rows  <- xml_find_all(sld, "//a:tr")
@@ -383,7 +392,7 @@ extract_table <- function(sld) {
 #' @param tbl_num The table number. Not produced in the caption, but used
 #'   to name the object and the code chunk. In typical application, corresponds
 #'   to the slide number.
-
+#' @keywords internal
 
 tribble_code <- function(df, tbl_num = "") {
 
@@ -421,6 +430,8 @@ import_notes_xml <- function(xml_folder) {
 #' @param inslides Logical. Should the notes be embedded in the slides?
 #'   Defaults to \code{TRUE}.
 #'
+#' @keywords internal
+
 extract_notes <- function(notes, sld_num, inslides = TRUE) {
 
   sld_notes_num <- map_dbl(notes,
@@ -485,6 +496,7 @@ write_notes <- function(xml_folder) {
 #' manipulated after conversion if you want other fonts with a specific theme.
 #' @param highlightStyle The code highlighting style. Defaults to
 #'   \code{"github"} flavored highlighting
+#' @keywords internal
 
 create_yaml <- function(title_sld, author, title = NULL, sub = NULL,
                         date = Sys.Date(), theme = "default",

--- a/man/create_yaml.Rd
+++ b/man/create_yaml.Rd
@@ -35,3 +35,4 @@ manipulated after conversion if you want other fonts with a specific theme.}
 Create the \href{https://github.com/yihui/xaringan}{xaringan} YAML Front
 Matter
 }
+\keyword{internal}

--- a/man/extract_attr.Rd
+++ b/man/extract_attr.Rd
@@ -17,3 +17,4 @@ extract_attr(rel, attr, sld)
 \description{
 Extract Attributes from the corresponding slide
 }
+\keyword{internal}

--- a/man/extract_body.Rd
+++ b/man/extract_body.Rd
@@ -12,3 +12,4 @@ extract_body(sld)
 \description{
 Extract the body of the slide
 }
+\keyword{internal}

--- a/man/extract_notes.Rd
+++ b/man/extract_notes.Rd
@@ -17,3 +17,4 @@ Defaults to \code{TRUE}.}
 \description{
 Function to pull notes from a slide
 }
+\keyword{internal}

--- a/man/extract_table.Rd
+++ b/man/extract_table.Rd
@@ -16,3 +16,4 @@ a \code{data.frame} with the data from the table. Generally fed to
 \description{
 Extract tables from slides
 }
+\keyword{internal}

--- a/man/extract_title.Rd
+++ b/man/extract_title.Rd
@@ -12,3 +12,4 @@ extract_title(sld)
 \description{
 Extract Slide Title
 }
+\keyword{internal}

--- a/man/extract_xml.Rd
+++ b/man/extract_xml.Rd
@@ -16,3 +16,4 @@ extract_xml(path, force = FALSE)
 \description{
 Extract xml from pptx
 }
+\keyword{internal}

--- a/man/import_rel_xml.Rd
+++ b/man/import_rel_xml.Rd
@@ -13,3 +13,4 @@ created from \code{\link{extract_xml}}.}
 \description{
 Import xml \code{rel} Code from PPTX
 }
+\keyword{internal}

--- a/man/import_slide_xml.Rd
+++ b/man/import_slide_xml.Rd
@@ -13,3 +13,4 @@ created from \code{\link{extract_xml}}.}
 \description{
 Import xml Code for PPTX Slides
 }
+\keyword{internal}

--- a/man/slidex-package.Rd
+++ b/man/slidex-package.Rd
@@ -51,5 +51,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Daniel Anderson \email{daniela@uoregon.edu}
 
+Other contributors:
+\itemize{
+  \item Patrick Kennedy \email{pkqstr@protonmail.com} (0000-0002-5525-3983) [contributor]
+}
+
 }
 \keyword{internal}

--- a/man/tribble_code.Rd
+++ b/man/tribble_code.Rd
@@ -17,3 +17,4 @@ to the slide number.}
 \description{
 Wrap a DF in \code{tibble::tribble} Code
 }
+\keyword{internal}


### PR DESCRIPTION
As described in #13, this excludes the functions in utils.R from the package manual/index.