### PR TITLE
Added `on.exit for `sink_rmd`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: slidex
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Title: Convert Microsoft PowerPoint Slides to R Markdown
 Description: This package is designed to extract information from Microsoft 
     PowerPoint slides, and then put that information into an R Markdown document 

--- a/R/utils.R
+++ b/R/utils.R
@@ -445,20 +445,22 @@ sink_rmd <- function(xml_folder, rmd, slds, rels,
   sld_notes <- import_notes_xml(xml_folder)
 
   sink(rmd)
-    cat(
-      create_yaml(title_sld, author, title, sub, date, theme, highlightStyle)
-    )
-    pmap(list(.x = slds, .y = rels, .z = seq_along(slds)),
-        function(.x, .y, .z)
-        cat("\n---",
-            extract_title(.x),
-            extract_body(.x),
-            tribble_code(extract_table(.x), tbl_num = .z),
-            extract_image(.x, .y),
-            extract_attr(.y, "link", .x),
-            extract_footnote(.x),
-            extract_notes(sld_notes, .z + 1),
-            sep = "\n")
-      )
-  sink()
+  cat(
+    create_yaml(title_sld, author, title, sub, date, theme, highlightStyle)
+  )
+  pmap(list(.x = slds, .y = rels, .z = seq_along(slds)),
+       function(.x, .y, .z)
+         cat("\n---",
+             extract_title(.x),
+             extract_body(.x),
+             tribble_code(extract_table(.x), tbl_num = .z),
+             extract_image(.x, .y),
+             extract_attr(.y, "link", .x),
+             extract_footnote(.x),
+             extract_notes(sld_notes, .z + 1),
+             sep = "\n")
+  )
+  on.exit({
+    sink()
+  })
 }


### PR DESCRIPTION
Added `on.exit` (with a simple indentation) and a version bump to fix the problem with any errors on `sink()` will make sure to exit with a `sink()` to close the `rmd` connection.